### PR TITLE
Theme fixes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -27,3 +27,8 @@ geekdocToC = 5
 geekdocCollapseSection = true
 geekdocBreadcrumb = true
 geekdocLogo = "logo.png"
+
+[minify]
+  [minify.tdewolff]
+    [minify.tdewolff.html]
+      keepWhitespace = true

--- a/static/custom.css
+++ b/static/custom.css
@@ -215,3 +215,20 @@ video {
 	max-width: 100%;
 	border-radius: .15rem;	
 }
+
+.gdoc-menu-header a {
+  color: var(--footer-link-color);
+}
+
+.gdoc-menu-header a:visited {
+  color: var(--footer-link-color-visited);
+}
+
+.gdoc-menu-header {
+  display: flex;
+  align-items: center;
+}
+
+.gdoc-menu-header > * {
+  margin-left: 0.5rem;
+}

--- a/themes/hugo-geekdoc/layouts/partials/site-footer.html
+++ b/themes/hugo-geekdoc/layouts/partials/site-footer.html
@@ -2,8 +2,8 @@
     <div class="container flex">
         <div class="flex flex-wrap">
             <span class="gdoc-footer__item gdoc-footer__item--row">
-                Built with <a href="https://gohugo.io/" class="gdoc-footer__link">Hugo</a> and
-                <svg class="icon gdoc_heart"><use xlink:href="#gdoc_heart"></use></svg>
+                Built with <a href="https://gohugo.io/" class="gdoc-footer__link">Hugo</a> and 
+                <span><svg class="icon gdoc_heart"><use xlink:href="#gdoc_heart"></use></svg></span>
             </span>
             {{ with .Site.Params.GeekdocLegalNotice }}
             <span class="gdoc-footer__item gdoc-footer__item--row">


### PR DESCRIPTION
This PR fixes some of the parts of the theme/site generator (no content edited)

- Keep whitespace on minifier to avoid spacing issues
- Fix spacing issue on the footer heart
- Fix position and color for "[Back to ProjectOutFox.co](https://projectoutfox.com/)" link

<details><summary>Image comparisons</summary>

## Breadcrumbs

| Comparison | Image |
| - | - |
| Before | ![image](https://user-images.githubusercontent.com/11584103/179388275-f8228c68-de69-4a5a-bef3-00676953255f.png)
| After | ![image](https://user-images.githubusercontent.com/11584103/179388268-de4739cc-df38-426e-bc0f-56c9aa9328a9.png)

## Header

| Comparison | Image |
| - | - |
| Before | ![image](https://user-images.githubusercontent.com/11584103/179388351-1f6aa119-7463-401a-82f3-8274939fdf65.png)
| After | ![image](https://user-images.githubusercontent.com/11584103/179388334-0a4bf12a-b2c2-4a62-b678-255ba29f9628.png)

## Footer

| Comparison | Image |
| - | - |
| Before | ![image](https://user-images.githubusercontent.com/11584103/179388304-6d124cc1-2515-4fd9-bfac-744aba83c63f.png)
| After | ![image](https://user-images.githubusercontent.com/11584103/179388318-952eb494-0057-4897-b4df-2b3d5b36e7b9.png)

</details>